### PR TITLE
Ability to maintain nullable DeletedAt column

### DIFF
--- a/soft_delete.go
+++ b/soft_delete.go
@@ -52,7 +52,7 @@ func (sd SoftDeleteQueryClause) ModifyStatement(stmt *gorm.Statement) {
 				clause.Eq{Column: clause.Column{Table: clause.CurrentTable, Name: sd.Field.DBName}, Value: 0},
 			}})
 		}
-		// stmt.Clauses["soft_delete_enabled"] = clause.Clause{}
+		stmt.Clauses["soft_delete_enabled"] = clause.Clause{}
 	}
 }
 

--- a/soft_delete.go
+++ b/soft_delete.go
@@ -43,10 +43,16 @@ func (sd SoftDeleteQueryClause) ModifyStatement(stmt *gorm.Statement) {
 			}
 		}
 
-		stmt.AddClause(clause.Where{Exprs: []clause.Expression{
-			clause.Eq{Column: clause.Column{Table: clause.CurrentTable, Name: sd.Field.DBName}, Value: 0},
-		}})
-		stmt.Clauses["soft_delete_enabled"] = clause.Clause{}
+		if sd.Field.DefaultValue == "null" {
+			stmt.AddClause(clause.Where{Exprs: []clause.Expression{
+				clause.Eq{Column: clause.Column{Table: clause.CurrentTable, Name: sd.Field.DBName}, Value: nil},
+			}})
+		} else {
+			stmt.AddClause(clause.Where{Exprs: []clause.Expression{
+				clause.Eq{Column: clause.Column{Table: clause.CurrentTable, Name: sd.Field.DBName}, Value: 0},
+			}})
+		}
+		// stmt.Clauses["soft_delete_enabled"] = clause.Clause{}
 	}
 }
 


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

Now we can define ```default:null``` flag in the model definition and soft delete will act accordingly.

```golang
package models

import (
	"gorm.io/gorm"
	"gorm.io/plugin/soft_delete"
)

type Test struct {
	ID           uint64                `gorm:"column:id;primaryKey" json:"id"`
	CreatedAt    uint64                `gorm:"column:created_at" json:"created_at"`
	UpdatedAt    uint64                `gorm:"column:updated_at" json:"updated_at"`
	DeletedAt    soft_delete.DeletedAt `gorm:"column:deleted_at;default:null" json:"deleted_at"`
}

func (Test) TableName() string {
	return "test"
}
```
