### PR TITLE
feat: support datetime on delete_at field

### DIFF
--- a/soft_delete_datetime.go
+++ b/soft_delete_datetime.go
@@ -1,0 +1,179 @@
+package soft_delete
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"reflect"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/schema"
+)
+
+type DeletedDateTime sql.NullTime
+
+var (
+	//DateTimeZero FlagActived
+	DateTimeZero  time.Time
+	DefaultLayout = "2006-01-02 15:04:05"
+)
+
+func init() {
+
+	DateTimeZero, _ = time.Parse(DefaultLayout, "1970-01-01 00:00:01")
+}
+
+// Scan implements the Scanner interface.
+func (n *DeletedDateTime) Scan(value interface{}) error {
+	return (*sql.NullTime)(n).Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (n DeletedDateTime) Value() (driver.Value, error) {
+	if !n.Valid {
+		return nil, nil
+	}
+	return n.Time, nil
+}
+
+func (DeletedDateTime) QueryClauses(f *schema.Field) []clause.Interface {
+	return []clause.Interface{SoftDeleteDateTimeQueryClause{Field: f}}
+}
+
+type SoftDeleteDateTimeQueryClause struct {
+	Field *schema.Field
+}
+
+func (sd SoftDeleteDateTimeQueryClause) Name() string {
+	return ""
+}
+
+func (sd SoftDeleteDateTimeQueryClause) Build(clause.Builder) {
+}
+
+func (sd SoftDeleteDateTimeQueryClause) MergeClause(*clause.Clause) {
+}
+
+func (sd SoftDeleteDateTimeQueryClause) ModifyStatement(stmt *gorm.Statement) {
+	if _, ok := stmt.Clauses["soft_delete_enabled"]; !ok && !stmt.Statement.Unscoped {
+		if c, ok := stmt.Clauses["WHERE"]; ok {
+			if where, ok := c.Expression.(clause.Where); ok && len(where.Exprs) >= 1 {
+				for _, expr := range where.Exprs {
+					if orCond, ok := expr.(clause.OrConditions); ok && len(orCond.Exprs) == 1 {
+						where.Exprs = []clause.Expression{clause.And(where.Exprs...)}
+						c.Expression = where
+						stmt.Clauses["WHERE"] = c
+						break
+					}
+				}
+			}
+		}
+
+		stmt.AddClause(clause.Where{Exprs: []clause.Expression{
+			clause.Eq{Column: clause.Column{Table: clause.CurrentTable, Name: sd.Field.DBName}, Value: DateTimeZero.Format(DefaultLayout)},
+		}})
+		stmt.Clauses["soft_delete_enabled"] = clause.Clause{}
+	}
+}
+
+func (DeletedDateTime) UpdateClauses(f *schema.Field) []clause.Interface {
+	return []clause.Interface{SoftDeleteDateTimeUpdateClause{Field: f}}
+}
+
+type SoftDeleteDateTimeUpdateClause struct {
+	Field *schema.Field
+}
+
+func (sd SoftDeleteDateTimeUpdateClause) Name() string {
+	return ""
+}
+
+func (sd SoftDeleteDateTimeUpdateClause) Build(clause.Builder) {
+}
+
+func (sd SoftDeleteDateTimeUpdateClause) MergeClause(*clause.Clause) {
+}
+
+func (sd SoftDeleteDateTimeUpdateClause) ModifyStatement(stmt *gorm.Statement) {
+	if stmt.SQL.Len() == 0 && !stmt.Statement.Unscoped {
+		SoftDeleteDateTimeQueryClause(sd).ModifyStatement(stmt)
+	}
+}
+
+func (DeletedDateTime) DeleteClauses(f *schema.Field) []clause.Interface {
+	settings := schema.ParseTagSetting(f.TagSettings["SOFTDELETE"], ",")
+	softDeleteClause := SoftDeleteDateTimeDeleteClause{
+		Field:    f,
+		Flag:     settings["FLAG"] != "",
+		TimeType: getTimeType(settings),
+	}
+	if v := settings["DELETEDATETIMEFIELD"]; v != "" { // DeleteDateTimeField
+		softDeleteClause.DeleteDateTimeField = f.Schema.LookUpField(v)
+	}
+	return []clause.Interface{softDeleteClause}
+}
+
+type SoftDeleteDateTimeDeleteClause struct {
+	Field               *schema.Field
+	Flag                bool
+	TimeType            schema.TimeType
+	DeleteDateTimeField *schema.Field
+}
+
+func (sd SoftDeleteDateTimeDeleteClause) Name() string {
+	return ""
+}
+
+func (sd SoftDeleteDateTimeDeleteClause) Build(clause.Builder) {
+}
+
+func (sd SoftDeleteDateTimeDeleteClause) MergeClause(*clause.Clause) {
+}
+
+func (sd SoftDeleteDateTimeDeleteClause) ModifyStatement(stmt *gorm.Statement) {
+	if stmt.SQL.Len() == 0 && !stmt.Statement.Unscoped {
+		var (
+			curTime = stmt.DB.NowFunc()
+			set     clause.Set
+		)
+
+		if deleteAtField := sd.DeleteDateTimeField; deleteAtField != nil {
+			var value interface{}
+			set = append(set, clause.Assignment{Column: clause.Column{Name: deleteAtField.DBName}, Value: curTime})
+			stmt.SetColumn(deleteAtField.DBName, value, true)
+		}
+
+		if sd.Flag {
+			set = append(clause.Set{{Column: clause.Column{Name: sd.Field.DBName}, Value: FlagDeleted}}, set...)
+			stmt.SetColumn(sd.Field.DBName, FlagDeleted, true)
+			stmt.AddClause(set)
+		} else {
+			set = append(clause.Set{{Column: clause.Column{Name: sd.Field.DBName}, Value: curTime}}, set...)
+			stmt.AddClause(set)
+			stmt.SetColumn(sd.Field.DBName, curTime, true)
+		}
+
+		if stmt.Schema != nil {
+			_, queryValues := schema.GetIdentityFieldValuesMap(stmt.Context, stmt.ReflectValue, stmt.Schema.PrimaryFields)
+			column, values := schema.ToQueryValues(stmt.Table, stmt.Schema.PrimaryFieldDBNames, queryValues)
+
+			if len(values) > 0 {
+				stmt.AddClause(clause.Where{Exprs: []clause.Expression{clause.IN{Column: column, Values: values}}})
+			}
+
+			if stmt.ReflectValue.CanAddr() && stmt.Dest != stmt.Model && stmt.Model != nil {
+				_, queryValues = schema.GetIdentityFieldValuesMap(stmt.Context, reflect.ValueOf(stmt.Model), stmt.Schema.PrimaryFields)
+				column, values = schema.ToQueryValues(stmt.Table, stmt.Schema.PrimaryFieldDBNames, queryValues)
+
+				if len(values) > 0 {
+					stmt.AddClause(clause.Where{Exprs: []clause.Expression{clause.IN{Column: column, Values: values}}})
+				}
+			}
+		}
+
+		SoftDeleteDateTimeQueryClause{Field: sd.Field}.ModifyStatement(stmt)
+		stmt.AddClauseIfNotExists(clause.Update{})
+		stmt.Build(stmt.DB.Callback().Update().Clauses...)
+	}
+}

--- a/soft_delete_datetime_test.go
+++ b/soft_delete_datetime_test.go
@@ -1,0 +1,89 @@
+package soft_delete
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type Book struct {
+	ID        uint
+	Name      string
+	Pages     uint
+	DeletedAt DeletedDateTime `gorm:"default:'1970-01-01 00:00:01'"`
+}
+
+func TestSoftDeleteDateTime(t *testing.T) {
+	DB, err := gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
+	DB = DB.Debug()
+	if err != nil {
+		t.Errorf("failed to connect database")
+	}
+
+	book := Book{Name: "jinzhu", Pages: 10}
+	DB.Migrator().DropTable(&Book{})
+	DB.AutoMigrate(&Book{})
+	DB.Save(&book)
+
+	var count int64
+	if DB.Model(&Book{}).Where("name = ?", book.Name).Count(&count).Error != nil || count != 1 {
+		t.Errorf("Count soft deleted record, expects: %v, got: %v", 1, count)
+	}
+
+	var pages uint
+	if DB.Model(&Book{}).Select("pages").Where("name = ?", book.Name).Scan(&pages).Error != nil || pages != book.Pages {
+		t.Errorf("Pages soft deleted record, expects: %v, got: %v", 0, pages)
+	}
+
+	if err := DB.Delete(&book).Error; err != nil {
+		t.Fatalf("No error should happen when soft delete user, but got %v", err)
+	}
+
+	if book.DeletedAt.Time.Equal(DateTimeZero) {
+		t.Errorf("book's deleted at should not be zero, DeletedAt: %v", book.DeletedAt)
+	}
+
+	sql := DB.Session(&gorm.Session{DryRun: true}).Delete(&book).Statement.SQL.String()
+	if !regexp.MustCompile(`UPDATE .books. SET .deleted_at.=.* WHERE .books.\..id. = .* AND .books.\..deleted_at. = ?`).MatchString(sql) {
+		t.Fatalf("invalid sql generated, got %v", sql)
+	}
+
+	if DB.First(&Book{}, "name = ?", book.Name).Error == nil {
+		t.Errorf("Can't find a soft deleted record")
+	}
+
+	count = 0
+	if DB.Model(&Book{}).Where("name = ?", book.Name).Count(&count).Error != nil || count != 0 {
+		t.Errorf("Count soft deleted record, expects: %v, got: %v", 0, count)
+	}
+
+	pages = 0
+	if err := DB.Model(&Book{}).Select("pages").Where("name = ?", book.Name).Scan(&pages).Error; err != nil || pages != 0 {
+		t.Fatalf("Age soft deleted record, expects: %v, got: %v, err %v", 0, pages, err)
+	}
+
+	if err := DB.Unscoped().First(&Book{}, "name = ?", book.Name).Error; err != nil {
+		t.Errorf("Should find soft deleted record with Unscoped, but got err %s", err)
+	}
+
+	count = 0
+	if DB.Unscoped().Model(&Book{}).Where("name = ?", book.Name).Count(&count).Error != nil || count != 1 {
+		t.Errorf("Count soft deleted record, expects: %v, count: %v", 1, count)
+	}
+
+	pages = 0
+	if DB.Unscoped().Model(&Book{}).Select("pages").Where("name = ?", book.Name).Scan(&pages).Error != nil || pages != book.Pages {
+		t.Errorf("Age soft deleted record, expects: %v, got: %v", 0, pages)
+	}
+
+	DB.Unscoped().Delete(&book)
+	if err := DB.Unscoped().First(&Book{}, "name = ?", book.Name).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Errorf("Can't find permanently deleted record")
+	}
+
+}


### PR DESCRIPTION
```
type Book struct {
	ID        uint
	Name      string
	Pages     uint
	DeletedAt soft_delete.DeletedDateTime `gorm:"default:'1970-01-01 00:00:01'"`
}
```
it may be necessary for us to set the type of `delete_at` datetime. and if delete_at is null, we can not add it into the composite index. so we can use as `1970-01-01 00:00:01` as zero value.
if we query books, gorm can generate the sql automatically 
```
select * from books where delete_at = '1970-01-01 00:00:01'
```
if we delete books, gorm can generate the sql automatically 
```
update books set  delete_at = 'xx' where delete_at = '1970-01-01 00:00:01'
```